### PR TITLE
Fix the broken paper path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Detector-Free Structure from Motion
-### [Project Page](https://zju3dv.github.io/DetectorFreeSfM/) | [Paper](https://zju3dv.github.io/DetectorFreeSfM/files/main_paper_with_sup.pdf)
+### [Project Page](https://zju3dv.github.io/DetectorFreeSfM/) | [Paper](https://zju3dv.github.io/DetectorFreeSfM/files/main_cvpr.pdf)
 <br/>
 
 > Detector-Free Structure from Motion                                                                                                                                                


### PR DESCRIPTION
Fixed the broken paper path by replacing it with the paper path from the project page.

PS: This is possibly not the correct paper. The authors intended to provide the paper with the supplementary material as it seems from the name of the pdf.